### PR TITLE
Fixing issue with get-resource on Windows machines

### DIFF
--- a/src/noir/io.clj
+++ b/src/noir/io.clj
@@ -25,7 +25,7 @@
    (get-resource \"/css/screen.css\" )"
   [relative-path]
   (if relative-path
-    (->> (.replaceAll relative-path "/" File/separator)
+    (->> relative-path
          (str "public")
          (io/resource))))
 


### PR DESCRIPTION
io/resource uses ClassLoader/getResource, which requires that the path
uses / to separate path names. Escaping / with File/separator (\ on
Windows) causes \ to be escaped in the file URL.
