### PR TITLE
fixed ordering of middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lib-noir "0.3.6"
+(defproject lib-noir "0.3.7"
   :description "Libraries from Noir for your enjoyment."
   :url "http://webnoir.org"
   :license {:name "Eclipse Public License - v 1.0"

--- a/src/noir/util/middleware.clj
+++ b/src/noir/util/middleware.clj
@@ -81,9 +81,9 @@
     (wrap-request-map)
     (wrap-noir-validation)
     (wrap-noir-cookies)
+    (wrap-noir-flash)
     (wrap-noir-session 
-      {:store (or store (memory-store mem))})
-    (wrap-noir-flash)))
+      {:store (or store (memory-store mem))})))
 
 (defn war-handler
   "wraps the app-handler in middleware needed for WAR deployment:


### PR DESCRIPTION
wrap-noir-flash has to come before wrap-noir-session in order to work correctly
