### PR TITLE
Few fixes in restricted macro.

### DIFF
--- a/src/noir/util/route.clj
+++ b/src/noir/util/route.clj
@@ -5,10 +5,10 @@
 (defmacro restricted
   "checks if any of the rules defined in wrap-access-rules match the method,
    if no rules match then the response is a redirect to \"/\""
-  [method url params body]
+  [method url params & body]
   `(~method ~url ~params
-     (let [rules# (:access-rules noir.request/*request*)]       
-       (if (or (nil? rules#) 
-               (some (fn [~'rule] (~'rule '~method ~url ~params)) rules#)) 
-         ~body 
+     (let [rules# (:access-rules noir.request/*request*)]
+       (if (or (nil? rules#)
+               (some (fn [rule#] (rule# '~method ~url ~params)) rules#))
+         (do ~@body)
          (noir.response/redirect "/")))))


### PR DESCRIPTION
Hey
As I understand 

``` clj
(fn [~'rule] (~'rule '~method ~url ~params)) 
```

is the same as just:

``` clj
(fn [rule] (rule '~method ~url ~params)) 
```

and in this case probably will be better to write it like :

``` clj
(fn [rule#] (rule# '~method ~url ~params)) 
```

Also will be great to have ability to pass more than one expression as body like in original compojure route, that is why I've added `(do ~@body)`

Thanks!
