### PR TITLE
Added some common website hashing functions

### DIFF
--- a/src/noir/util/crypt.clj
+++ b/src/noir/util/crypt.clj
@@ -15,13 +15,13 @@
                          (memfn toString)
                          [salt data])]
               (apply str [s d s])))
-        sha1-obj (doto (MessageDigest/getInstance instance-type)
+        hash-obj (doto (MessageDigest/getInstance instance-type)
                    .reset
                    (.update
                     (.getBytes _)))]
     (apply str
            (map (partial format "%02x")
-                (.digest sha1-obj)))))
+                (.digest hash-obj)))))
 
 (defn md5
   [data & salt]


### PR DESCRIPTION
``` clojure
noir.util.crypt=> (noir.util.crypt/md5 "abc")
"900150983cd24fb0d6963f7d28e17f72"
noir.util.crypt=> (noir.util.crypt/sha1 "abc")
"a9993e364706816aba3e25717850c26c9cd0d89d"
noir.util.crypt=> (noir.util.crypt/sha2 "abc")
"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
noir.util.crypt=> (noir.util.crypt/sha2 "abc" "salty")
"da3a54b1d94374ac909dcb5f34874a9f86b167040511023de41342e6f6e1222c"
```
