### PR TITLE
CSRF attack prevention middleware (partial)

### DIFF
--- a/src/noir/util/middleware.clj
+++ b/src/noir/util/middleware.clj
@@ -17,8 +17,6 @@
         [ring.middleware.file-info :only [wrap-file-info]]
         [ring.middleware.multipart-params :only [wrap-multipart-params]])
   (:require [clojure.string :as s]))
-<<<<<<< HEAD
-
 
 (defn csrf-protection-writer
   "Adds CSRF token to urls"
@@ -32,7 +30,7 @@
     ;; get errors thrown when trying to do
     ;; session actions wtihin the middleware
     (let [token (java.util.UUID/randomUUID)]
-      (-> (update-in 
+      (-> (update-in
            req
            [:query-string]
            (fn [x]
@@ -41,8 +39,6 @@
                (str "csrf=" token)
                (str x "&csrf=" token))))
           handler))))
-=======
->>>>>>> parent of e11c7da... CSRF attack prevention middleware (partial)
 
 (defn wrap-request-map [handler]
   (fn [req]
@@ -112,7 +108,8 @@
     (wrap-noir-cookies)
     (wrap-noir-flash)
     (wrap-noir-session 
-      {:store (or store (memory-store mem))})))
+      {:store (or store (memory-store mem))})
+    (csrf-protection-writer)))
 
 (defn war-handler
   "wraps the app-handler in middleware needed for WAR deployment:


### PR DESCRIPTION
It's partial because it lacks session support at the moment. Errors get thrown when I try to apply session functions from within the middleware extension.

I accidentally pushed the wrong emacs buffer 3 times, so please ignore the first 3.
Lines 21-40 & Line 112 at https://github.com/runexec/lib-noir/blob/e1fbc81be96117d033ca75c449b08dff79860d03/src/noir/util/middleware.clj
