### PR TITLE
doc: API: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Some of the core features includes the following:
 * route filtering and redirection
 * password hashing using [jBcryt](http://www.mindrot.org/projects/jBCrypt/) 
 
-See the [API](http://www.luminusweb.net/noir-api/index.html) for more details.
+See the [API](http://yogthos.github.com/lib-noir/index.html) for more details.
 
 This library was originally split out from the [Noir](https://github.com/noir-clojure/noir) web framework
 for your enjoyment.


### PR DESCRIPTION
The [API](http://www.luminusweb.net/noir-api/index.html) link is broken (404).

This [one is working](http://yogthos.github.com/lib-noir/index.html) 
