### PR TITLE
doctring typo: a string is parsed to a Long, not cast

### DIFF
--- a/src/noir/validation.clj
+++ b/src/noir/validation.clj
@@ -49,7 +49,7 @@
 
 
 (defn valid-number?
-  "Returns true if the string can be cast to a Long"
+  "Returns true if the string can be parsed to a Long"
   [v]
   (try
     (Long/parseLong v)


### PR DESCRIPTION
... at least not in this language ;-)
