### PR TITLE
added tests and an assertion for wrap-rewrites

### DIFF
--- a/src/noir/util/middleware.clj
+++ b/src/noir/util/middleware.clj
@@ -22,6 +22,8 @@
   "Rewrites should be [regex replacement] pairs. The first regex that matches the request's URI will
   have the corresponding (global) replacement performed before calling the wrapped handler."
   [handler & rewrites]
+  (if-not (even? (count rewrites))
+    (throw (Exception. (str "must have an even number of rewrites: " rewrites))))
   (let [rules (partition 2 rewrites)]
     (fn [req]
       (handler (update-in req [:uri]

--- a/test/noir/middleware_tests.clj
+++ b/test/noir/middleware_tests.clj
@@ -38,3 +38,10 @@
 (deftest test-wrap-strip-trailing-slash
   (is (= {:uri "/foo"} ((wrap wrap-strip-trailing-slash) {:uri "/foo/"}))))
 
+(deftest test-wrap-rewrites
+  (let [handler (fn [updated-req] updated-req)]
+    (is (= {:uri "/bar"} ((wrap-rewrites handler #"/foo" "/bar") {:uri "/foo"})))
+    (is (= {:uri "/bar"} ((wrap-rewrites handler #"/foo" "/bar") {:uri "/foo"})))    
+    (is (thrown? Exception ((wrap-rewrites handler #"/foo" "/bar" #"/baz") {:uri "/foo"})))
+    (is (= {:uri "/baz"} ((wrap-rewrites handler) {:uri "/baz"})))))
+


### PR DESCRIPTION
wrap-rewrites would work with an odd number of args, I figured it's best to throw an exception so it doesn't happen by accident :)
