### PR TITLE
Clean up docstring for def-restricted-routes

### DIFF
--- a/src/noir/util/route.clj
+++ b/src/noir/util/route.clj
@@ -51,14 +51,14 @@
    routes and calls Compojure defroutes, eg:
 
    (def-restricted-routes private-pages
-     (GET \"/profile\" [] (show-profile)
-     (GET \"/my-secret-page\" [] (show-secret-page))
+     (GET \"/profile\" [] (show-profile))
+     (GET \"/my-secret-page\" [] (show-secret-page)))
 
    is equivalent to:
 
    (defroutes private-pages
-     (GET \"/profile\" [] (restricted(show-profile))
-     (GET \"/my-secret-page\" [] (restricted (show-secret-page)))"
+     (GET \"/profile\" [] (restricted (show-profile)))
+     (GET \"/my-secret-page\" [] (restricted (show-secret-page))))"
   [name & routes]
   `(compojure.core/defroutes ~name
      ~@(for [[method# uri# params# & body#] routes]


### PR DESCRIPTION
In reading the [Lib-noir 0.6.6 API documentation](http://yogthos.github.io/lib-noir/noir.util.route.html), I noticed that the code examples for `def-restricted-routes` have a few missing parens, and a missing space. I've fixed that up in this patch to make it a little more readable.
