### PR TITLE
Move doc strings to correct place in defn, and partially corrected a tes...

### DIFF
--- a/src/noir/cookies.clj
+++ b/src/noir/cookies.clj
@@ -34,8 +34,9 @@
        v
        default))))
 
-(defn signed-name [k]
+(defn signed-name
   "Construct the name of the signing cookie using a simple suffix."
+  [k]
   (str (k->s k) "__s"))
 
 (defn put-signed!

--- a/src/noir/session.clj
+++ b/src/noir/session.clj
@@ -83,13 +83,14 @@
     *noir-session*
     #(apply (partial update-in % ks f) args)))
 
-(defn ^:private noir-session [handler]
+(defn ^:private noir-session
    "Store noir session keys in a :noir map, because other middleware that
    expects pure functions may delete keys, and simply merging won't work.
    Ring takes (not (contains? response :session) to mean: don't update session.
    Ring takes (nil? (:session resonse) to mean: delete the session.
    Because noir-session mutates :session, it needs to duplicate ring/wrap-session
    functionality to handle these cases."
+  [handler]
   (fn [request]
     (binding [*noir-session* (atom (clojure.core/get-in request [:session :noir] {}))]
       (remove! :_flash)

--- a/src/noir/util/crypt.clj
+++ b/src/noir/util/crypt.clj
@@ -52,8 +52,9 @@
   [raw encrypted]
   (BCrypt/checkpw raw encrypted))
 
-(defn sha1-sign-hex [sign-key v]
+(defn sha1-sign-hex
   "Using a signing key, compute the sha1 hmac of v and convert to hex."
+  [sign-key v]
   (let [mac (javax.crypto.Mac/getInstance "HmacSHA1")
         secret (javax.crypto.spec.SecretKeySpec. (.getBytes sign-key), "HmacSHA1")]
     (.init mac secret)

--- a/test/noir/cache_tests.clj
+++ b/test/noir/cache_tests.clj
@@ -24,7 +24,7 @@
   (cache! :foo "foo")
   (cache! :bar "bar")
   (cache! :baz "baz")
-  (= [:bar :baz] (->> @cached :items (map keys))))
+  (is (= #{:bar :baz} (->> @cached :items keys set))))
 
 (deftest set-timeout!-test  
   (clear!)


### PR DESCRIPTION
...t

The test still fails, but it is because the implementation of cache!
allows the cache to go 1 over the max-size if it currently has
max-size elements, and then an item is added that is not already in
the cache.  I will let the lib-noir developers decide whether they want
to change the test to match the behavior, or change cache!

Issues found using a pre-release version of the Eastwood Clojure lint tool.
