### PR TITLE
return false from is-email? when input is nil

### DIFF
--- a/src/noir/validation.clj
+++ b/src/noir/validation.clj
@@ -44,7 +44,9 @@
 (defn is-email?
   "Returns true if v is an email address"
   [v]
-  (matches-regex? v #"(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"))
+  (if (nil? v)
+    false
+    (matches-regex? v #"(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")))
 
 
 (defn valid-file?

--- a/test/noir/validation_tests.clj
+++ b/test/noir/validation_tests.clj
@@ -51,8 +51,12 @@
   (is (= false
          (validation/is-email? "test")))
   (is (= false
-         (validation/is-email? "test@.net"))))
-         
+         (validation/is-email? "test@.net")))
+  (is (= false
+         (validation/is-email? "")))
+  (is (= false
+         (validation/is-email? nil))))
+
 (deftest test-greater-than?
   (is (= true
         (validation/greater-than? "2" 1)))


### PR DESCRIPTION
Previous behaviour was to allow the call to matches-regex? to raise an exception
when the input value was nil. This causes problems when using noir.validation
to validate inputs to (for example) a restful service, where it is possible for
the client to omit fields from the input data.

See: https://github.com/noir-clojure/lib-noir/issues/97

Tests have been updated to cover both nil and empty string as inputs to the
is-email? function. All test passing
