### PR TITLE
Fix noir.io/resource-path on Windows

### DIFF
--- a/src/noir/io.clj
+++ b/src/noir/io.clj
@@ -5,7 +5,7 @@
 (defn resource-path
   "returns the path to the public folder of the application"
   []
-  (if-let [path (io/resource (str "public" File/separator))]
+  (if-let [path (io/resource "public/")]
     (.getPath path)))
 
 (defn- file-path [path & [filename]]


### PR DESCRIPTION
clojure.java.io/resource requires that paths are always '/'-separated
(due to dependency on ClassLoader.getResource)
