### PR TITLE
Should fix StackOverflow error when calling the deprecated `clear-errors`

### DIFF
--- a/src/noir/validation.clj
+++ b/src/noir/validation.clj
@@ -122,7 +122,7 @@
 (defn clear-errors
   ^{:doc "Original name for clear-errors!. Use that instead."
     :deprecated "0.8.0"}
-  [] (clear-errors))
+  [] (clear-errors!))
 
 (defn rule
   "If the passed? condition is not met, add the error text to the given field:


### PR DESCRIPTION
Should fix StackOverflow error due to infinite recursive call on `clear-errors` (the deprecated name for `clear-errors!`).
