### PR TITLE
Add utility function related anti forgery

### DIFF
--- a/src/noir/util/anti_forgery.clj
+++ b/src/noir/util/anti_forgery.clj
@@ -1,0 +1,10 @@
+(ns noir.util.anti-forgery
+  "Utility functions for inserting anti-forgery tokens into HTML forms."
+  (:require [ring.util.anti-forgery :as anti-forgery]))
+
+(defn anti-forgery-field
+  "Create a hidden field with the session anti-forgery token as its value.
+  This ensures that the form it's inside won't be stopped by the anti-forgery
+  middleware."
+  []
+  (anti-forgery/anti-forgery-field))


### PR DESCRIPTION
Just add an function that about helper function for HTML form.

WHY:
This library depends on ring/ring-anti-forgery implicitly (because using
ring/ring-defaults). It's a enable by default.
User need add the few dependencies at a controller file, like this.

(use 'ring.util.anti-forgery)

(form-to \[:post "/something"\]
  (anti-forgery-field)

That's a little bit strange for me. Because I didn't added the
ring/ring-anti-forgery library explicitly.
So, I just want to write this

(use 'noir.util.anti-forgery)

(form-to \[:post "/something"\]
  (anti-forgery-field)

That's why I added an function as a helper function for HTML form.